### PR TITLE
Avoid converting a getter/setter into an invalid async method

### DIFF
--- a/__tests__/async-await-test.js
+++ b/__tests__/async-await-test.js
@@ -658,4 +658,26 @@ describe('async-await', () => {
       }
     );
   });
+
+  describe('es6 getter and setter should be unchanged', function() {
+    defineTestFromFunctions(
+      () => {
+        class A {
+          method() {return a().then(b => 'convert')}
+          get prop() {return a().then(b => 'getter')}
+          set prop(val) {return a(val).then(b => 'setter')}
+        }
+      },
+      () => {
+        class A {
+          async method() {
+            const b = await a();
+            return 'convert';
+          }
+          get prop() {return a().then(b => 'getter')}
+          set prop(val) {return a(val).then(b => 'setter')}
+        }
+      },
+    );
+  });
 });

--- a/async-await.js
+++ b/async-await.js
@@ -104,6 +104,14 @@ module.exports = function transformer(file, api) {
       return;
     }
 
+    // Don't transform get x() {…} into async get x() {…}; that would generate invalid syntax
+    if (
+      p.parent.node.type === 'MethodDefinition' &&
+      (p.parent.node.kind === 'get' || p.parent.node.kind === 'set')
+    ) {
+      return;
+    }
+
     // Set function to async
     node.async = true;
 


### PR DESCRIPTION
Previously, async-await.js would convert a getter/setter into an invalid async getter/setter.

Input:

```js
class A {
  method() {return a().then(b => 'convert')}
  get prop() {return a().then(b => 'getter')}
  set prop(val) {return a(val).then(b => 'setter')}
}
```

Output before this PR: `async get` and `async set` methods are created, but this is invalid ECMAScript and invalid TypeScript:

```js
class A {
  async method() {
    const b = await a();
    return 'convert';
  }
  async get prop() {
    const b = await a();
    return 'getter';
  }
  async set prop(val) {
    const b = await a(val);
    return 'setter';
  }
}
```

Output after this PR: `get` and `set` methods are not converted to async.
```
class A {
  async method() {
    const b = await a();
    return 'convert';
  }
  get prop() {return a().then(b => 'getter')}
  set prop(val) {return a(val).then(b => 'setter')}
}
```